### PR TITLE
Loose the regex requirements for recognising functions that are to be available in a remote proxy.

### DIFF
--- a/src/haxe/remoting/Macros.hx
+++ b/src/haxe/remoting/Macros.hx
@@ -325,8 +325,8 @@ class Macros
 			fields.push(MacroUtil.createConnectionField(pos));
 		}
 		
-		var remoteMetaRegex : EReg = ~/^[ \t]@remote.*/;
-		var functionRegex : EReg = ~/^[\t ]*(public)?[\t ]*function.*/;
+		var remoteMetaRegex : EReg = ~/^[ \t]*@remote.*/;
+		var functionRegex : EReg = ~/[\t ]*(public)?[\t ]*function.*/;
 		var interfaceRegex : EReg = ~/.*\n[\t ]*interface[\t ].*/;
 		var interfaceFunctionExprs = [];
 		


### PR DESCRIPTION
```
Line 328: Allow multiple spaces (or tabs) before "@remote" on a single line
Line 329: Allow you to put "@remote" (or other metadata) on the same line as a function declaration.
```
